### PR TITLE
Fixed mapping of references, in particular Patient

### DIFF
--- a/src/main/kotlin/com/diameterhealth/cpcds/CPCDSToFHIRMapper.kt
+++ b/src/main/kotlin/com/diameterhealth/cpcds/CPCDSToFHIRMapper.kt
@@ -35,7 +35,13 @@ fun mapToExplanationOfBenefits(row: CPCDSRow): ExplanationOfBenefit {
         )        // TODO: Made up system
     }
 
-    if (!row.memberId.isNullOrBlank()) {
+    if (!row.patientAccountNumber.isNullOrBlank()) {
+        eob.patient =
+            reference(
+                row.patientAccountNumber,
+                "Patient"
+            )
+    } else if (!row.memberId.isNullOrBlank()) {
         eob.patient =
             reference(
                 row.memberId,
@@ -911,11 +917,7 @@ private fun addSupportingInfo(
 }
 
 private fun reference(id: String?, type: String? = null): Reference {
-    return Reference().setIdentifier(
-        identifier(
-            id
-        )
-    ).setType(type)
+    return Reference().setReference("${type}/${id}")
 }
 
 

--- a/src/test/kotlin/com/diameterhealth/cpcds/ConverterTest.kt
+++ b/src/test/kotlin/com/diameterhealth/cpcds/ConverterTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
+import org.junit.jupiter.api.Assertions.*
 
 class ConverterTest {
 
@@ -40,6 +41,21 @@ class ConverterTest {
         verify(sourceAdapter).exists(any())
         verify(sourceAdapter).create(any())
         verify(sourceAdapter, times(0)).update(any(), any())
+    }
+
+
+    @Test
+    fun `one claim is has correct patient reference`() {
+        Mockito.`when`(sourceAdapter.exists(any())).thenReturn(null)
+        Mockito.`when`(sourceAdapter.create(any())).thenAnswer { invocation ->
+                val eob = invocation.arguments[0] as ExplanationOfBenefit
+                assertEquals("Patient/57ecca3a-7157-414f-bc00-1345618b9656", eob.patient.reference)
+
+                "TEST_ID"
+        }
+
+        val file = "data/CPCDS_Claims_one_claim.csv".asResourceFile()
+        convert(file, sourceAdapter, null)
     }
 
     @Test


### PR DESCRIPTION
Also the Patient Id should be mapped to Patient Account Number based on how Synthea is using it at the time this test data was generated.